### PR TITLE
Add missing ID param for PUT calls

### DIFF
--- a/lib/kubr/client.rb
+++ b/lib/kubr/client.rb
@@ -45,8 +45,8 @@ module Kubr
           send_request :post, entity.pluralize, config
         end
 
-        define_method "update_#{entity.underscore}" do |config|
-          send_request :put, entity.pluralize, config
+        define_method "update_#{entity.underscore}" do |id, config|
+          send_request :put, "#{entity.pluralize}/#{id}", config
         end
 
         define_method "delete_#{entity.underscore}" do |id|


### PR DESCRIPTION
According to the k8s docs it looks like all of the PUT operations require that an ID also be specified:

http://cdn.rawgit.com/GoogleCloudPlatform/kubernetes/31a0daae3627c91bc96e1f02a6344cd76e294791/api/kubernetes.html
