### PR TITLE
Require active_support before core_ext

### DIFF
--- a/lib/core_ext/hash.rb
+++ b/lib/core_ext/hash.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 
 


### PR DESCRIPTION
Causes 

```
/home/user/.gem/ruby/2.3.1/gems/activesupport-4.2.6/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```

on some rubies if not required first.  See:  https://github.com/rails/rails/issues/14664
